### PR TITLE
Replace deprecated "max()" with "max.()" for matrices.

### DIFF
--- a/src/generators.jl
+++ b/src/generators.jl
@@ -62,7 +62,7 @@ function erdos_renyi_undirected(n::Int, p::Float64)
     else
         Aup = A
     end
-    Asym = max(Aup,Aup')
+    Asym = max.(Aup,Aup')
     return _matrix_network_direct(Asym,1)
 end
 erdos_renyi_undirected(n::Int, d::Int) = erdos_renyi_undirected(n, d/n)

--- a/src/largest_component.jl
+++ b/src/largest_component.jl
@@ -36,7 +36,7 @@ end
 function largest_component{T}(A::SparseMatrixCSC{T,Int64},sym::Bool)
     if sym
         # As = A|A' until Julia implements this on sparse matrices, use this:
-        As = max(A,A')
+        As = max.(A,A')
         cc = scomponents(As)
     else
         cc = scomponents(A)

--- a/src/mst_prim.jl
+++ b/src/mst_prim.jl
@@ -29,7 +29,7 @@ Example
 ~~~
 A = load_matrix_network("airports")
 A = -A #convert to travel time
-A = max(A,A')
+A = max.(A,A')
 A = sparse(A)
 (ti,tj,tv,nverts) = mst_prim(A)
 ~~~


### PR DESCRIPTION
On Julia v0.6, I was getting the following warning:
"WARNING: max{T1 <: Real, T2 <: Real}(x::AbstractArray{T1}, y::AbstractArray{T2}) is deprecated, use max.(x, y) instead."

