### PR TITLE
bipartite cardinality matching

### DIFF
--- a/src/MatrixNetworks.jl
+++ b/src/MatrixNetworks.jl
@@ -72,7 +72,7 @@ include("spectral.jl")
 export fiedler_vector, sweepcut, spectral_cut, bestset, SweepcutProfile
 
 # export everything to make them accessible as functions
-export bipartite_matching, edge_list, create_sparse,
+export bipartite_matching, bipartite_cardinality_matching, edge_list, create_sparse,
 bipartite_matching_setup, bipartite_matching_indicator, bfs,
 dfs, clustercoeffs, corenums, scomponents, strong_components_map,
 enrich, csr_to_sparse, floydwarshall, largest_component,

--- a/src/bipartite_matching.jl
+++ b/src/bipartite_matching.jl
@@ -316,7 +316,7 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
         index_ei = zeros(Int, m+1)
         last = ei[1]
         c = 2
-        for i = 2:len
+        @inbounds for i = 2:len
             if ei[i] != last
                 index_ei[last+1] = c
                 last = ei[i]
@@ -324,9 +324,7 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
             c += 1
         end
         index_ei[ei[end]+1] = c
-
         index_ei[1] = 1
-
 
         process_nodes = zeros(Int, m+n)
         depths = zeros(Int, m+n)
@@ -336,7 +334,7 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
         found = false
 
         # find augmenting path
-        while match_len < m
+        @inbounds while match_len < m
             pend = 1
             pstart = 1
             for ei_i in ei
@@ -348,7 +346,6 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
                 end
             end
 
-            begin
             while pstart <= pend
                 node = process_nodes[pstart]
                 depth = depths[pstart]
@@ -412,7 +409,6 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
                 found = false
             else 
                 break
-            end
             end
         end
     end

--- a/src/bipartite_matching.jl
+++ b/src/bipartite_matching.jl
@@ -287,7 +287,6 @@ end
 
 function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, m, n; ei_sorted=false)
     @assert length(ei_in) == length(ej_in)
-    @assert m <= n
     ei = ei_in
     ej = ej_in
     if !ei_sorted
@@ -311,7 +310,7 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
     end
 
 
-    if match_len < m
+    if match_len < m && match_len < n
         # creating indices be able to get edges a vertex is connected to
         # only works if l is sorted
         index_ei = zeros(Int, m+1)
@@ -449,6 +448,11 @@ end
 function bipartite_cardinality_matching(ei::Vector{Int64},
     ej::Vector{Int64}; ei_sorted=false)
     return bipartite_cardinality_matching(ei,ej,maximum(ei),maximum(ej); ei_sorted=false)
+end
+
+function bipartite_cardinality_matching(A::SparseMatrixCSC{T,Int64}) where T 
+    ei,ej,w = findnz(A)
+    return bipartite_cardinality_matching(ei,ej,A.m,A.n; ei_sorted=false)
 end
 
 ####################

--- a/src/bipartite_matching.jl
+++ b/src/bipartite_matching.jl
@@ -335,75 +335,91 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
 
         # find augmenting path
         @inbounds while match_len < m
-            pend = 1
-            pstart = 1
+            found = false
+            
             for ei_i in ei
                 # free vertex
                 if matching_ei[ei_i] == 0
+                    pend = 1
+                    pstart = 1
                     process_nodes[pstart] = ei_i
                     depths[pstart] = 1
-                    break
-                end
-            end
 
-            while pstart <= pend
-                node = process_nodes[pstart]
-                depth = depths[pstart]
-                
-                # from ei to ej
-                if depth % 2 == 1
-                    # only works if ei is sorted
-                    for ej_i = index_ei[node]:index_ei[node+1]-1
-                        child_node = ej[ej_i]
-                        # don't use matching edge
-                        if matching_ej[child_node] != node && !used_ej[child_node]
-                            used_ej[child_node] = true
-                            pend += 1
-                            depths[pend] = depth+1
-                            process_nodes[pend] = child_node
-                            parents[pend] = pstart
-                        end
-                    end
-                else # ej to ei (only matching edge)
-                    # if matching edge
-                    match_to = matching_ej[node]
-                    if match_to != 0
-                        if !used_ei[match_to]
-                            used_ei[match_to] = true
-                            pend += 1
-                            depths[pend] = depth+1
-                            process_nodes[pend] = match_to
-                            parents[pend] = pstart
-                        end
-                    else
-                        # found augmenting path
-                        parent = pstart
-                        last = 0
-                        c = 0
-                        while parent != 0
-                            current = process_nodes[parent]
-                            if last != 0 
-                                if c % 2 == 1
-                                    matching_ej[last] = current
-                                    matching_ei[current] = last
+                    # while there are open vertices
+                    while pstart <= pend
+                        node = process_nodes[pstart]
+                        depth = depths[pstart]
+                        
+                        # from ei to ej
+                        if depth % 2 == 1
+                            # only works if ei is sorted
+                            for ej_i = index_ei[node]:index_ei[node+1]-1
+                                child_node = ej[ej_i]
+                                # if connected to free vertex
+                                if matching_ej[child_node] == 0
+                                    # found augmenting path
+                                    parent = pstart
+                                    last = child_node
+                                    c = 0
+                                    while parent != 0
+                                        current = process_nodes[parent]
+                                        if c % 2 == 0
+                                            matching_ej[last] = current
+                                            matching_ei[current] = last
+                                        end
+                                        c += 1
+                                        last = current
+                                        parent = parents[parent]
+                                    end
+                                    # break because we found a path
+                                    found = true
+                                    break
+                                end
+                                
+                                # don't use matching edge
+                                if matching_ej[child_node] != node && !used_ej[child_node]
+                                    used_ej[child_node] = true
+                                    pend += 1
+                                    depths[pend] = depth+1
+                                    process_nodes[pend] = child_node
+                                    parents[pend] = pstart
                                 end
                             end
-                            c += 1
-                            last = current
-                            parent = parents[parent]
+                            found && break
+                        else # ej to ei (only matching edge)
+                            # if matching edge
+                            match_to = matching_ej[node]
+                            # there has to be a matching edge otherwise we would have find an 
+                            # augmenting path
+                            @assert match_to != 0
+                            if !used_ei[match_to]
+                                used_ei[match_to] = true
+                                pend += 1
+                                depths[pend] = depth+1
+                                process_nodes[pend] = match_to
+                                parents[pend] = pstart
+                            end
                         end
-                        # break because we found a path
-                        found = true
-                        break
+                        pstart += 1
                     end
                 end
-                pstart += 1
+                if !found
+                    used_ei .= false
+                    used_ej .= false
+                    process_nodes .= 0
+                    depths        .= 0
+                    parents       .= 0
+                end
+                found && break
             end
             if found
                 match_len += 1
                 if match_len < m
                     used_ei .= false
                     used_ej .= false
+                    process_nodes .= 0
+                    depths        .= 0
+                    parents       .= 0
                 end
                 found = false
             else 

--- a/src/bipartite_matching.jl
+++ b/src/bipartite_matching.jl
@@ -350,11 +350,10 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
                 node = process_nodes[pstart]
                 depth = depths[pstart]
                 
-                # from left to right
+                # from ei to ej
                 if depth % 2 == 1
-                    used_ei[node] = true
-                    # only works if l is sorted
-                    for ej_i=index_ei[node]:index_ei[node+1]-1
+                    # only works if ei is sorted
+                    for ej_i = index_ei[node]:index_ei[node+1]-1
                         child_node = ej[ej_i]
                         # don't use matching edge
                         if matching_ej[child_node] != node && !used_ej[child_node]
@@ -365,7 +364,7 @@ function bipartite_cardinality_matching(ei_in::Vector{Int}, ej_in::Vector{Int}, 
                             parents[pend] = pstart
                         end
                     end
-                else # right to left (only matching edge)
+                else # ej to ei (only matching edge)
                     # if matching edge
                     match_to = matching_ej[node]
                     if match_to != 0

--- a/test/bipartite_matching_test.jl
+++ b/test/bipartite_matching_test.jl
@@ -38,3 +38,37 @@ using LinearAlgebra
     
     @test M2.weight == 25/maximum(abs.(av)) && isequal(m1,m2) && sum(mi) ==5 && isequal(mi,mitrue)
 end
+
+
+@testset "bipartite_cardinality_matching_test" begin
+    mo_car = bipartite_cardinality_matching([1,2,3],[3,2,4])
+    mo_car_sorted = bipartite_cardinality_matching([1,2,3],[3,2,4]; ei_sorted=true)
+    @test mo_car.cardinality == 3
+    @test mo_car_sorted.cardinality == 3
+    @test allunique(mo_car_sorted.match)
+
+    # max cardinality not as big as m
+    ei = [1,1,3,3,3,3,1,2,4,4,5,6,6,7,8,8]
+    ej = [2,3,2,3,4,5,6,1,4,5,6,5,6,2,7,8]
+    w = ones(length(ei))
+    mo_car = bipartite_cardinality_matching(ei, ej)
+    mo_max = bipartite_matching(w, ei, ej)
+    @test mo_car.cardinality == mo_max.cardinality
+    @test mo_car.cardinality == 7
+    # unmatched vertices have a 0 at the position
+    matched = filter(v->v!=0, mo_car.match)
+    @test length(matched) == mo_car.cardinality
+    @test allunique(matched)
+
+    # max cardinality now same as m
+    ei = [1,1,3,3,3,3,1,2,4,4,5,6,6,7,8,8,4]
+    ej = [2,3,2,3,4,5,6,1,4,5,6,5,6,2,7,8,8]
+    w = ones(length(ei))
+    mo_car = bipartite_cardinality_matching(ei, ej)
+    mo_max = bipartite_matching(w, ei, ej)
+    @test mo_car.cardinality == mo_max.cardinality
+    @test mo_car.cardinality == 8
+    # unmatched vertices have a 0 at the position
+    @test allunique(mo_car.match)
+
+end

--- a/test/bipartite_matching_test.jl
+++ b/test/bipartite_matching_test.jl
@@ -68,7 +68,27 @@ end
     mo_max = bipartite_matching(w, ei, ej)
     @test mo_car.cardinality == mo_max.cardinality
     @test mo_car.cardinality == 8
-    # unmatched vertices have a 0 at the position
     @test allunique(mo_car.match)
 
+    # m > n
+    ei = [1,1,3,3,3,3,1,2,4,4,5,6,6,7,8,8,4,9]
+    ej = [2,3,2,3,4,5,6,1,4,5,6,5,6,2,7,8,8,1]
+    w = ones(length(ei))
+    mo_car = bipartite_cardinality_matching(ei, ej)
+    mo_max = bipartite_matching(w, ei, ej)
+    @test mo_car.cardinality == mo_max.cardinality
+    @test mo_car.cardinality == 8
+    # unmatched vertices have a 0 at the position
+    matched = filter(v->v!=0, mo_car.match)
+    @test length(matched) == mo_car.cardinality
+    @test allunique(matched)
+
+    # having a sparse matrix
+    ei = [1,1,3,3,3,3,1,2,4,4,5,6,6,7,8,8,4]
+    ej = [2,3,2,3,4,5,6,1,4,5,6,5,6,2,7,8,8]
+    w = ones(length(ei))
+    A = sparse(ei, ej, w)
+    mo_car = bipartite_cardinality_matching(A)
+    @test mo_car.cardinality == 8
+    @test allunique(mo_car.match)
 end


### PR DESCRIPTION
Maybe can be faster with an implementation of the Hopcroft Karp algorithm but read that this is normally not faster than the basic BFS implementation.
If this looks good I'll of course add it to the `README`.

Additionally:

- [ ]  There is probably a faster implementation for unsorted `ei`
- [X] Needs implementation for a sparse matrix as bipartite matching has it
- [X] Remove the `m <= n` constraint
