### PR TITLE
support DataStructures v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Arpack = "0.4.0"
-DataStructures = "0.17.17"
+DataStructures = "0.17.17, 0.18"
 IterTools = "1.3.0"
 KahanSummation = "0.1.0"
 julia = "1"


### PR DESCRIPTION
There doesn't seem to be an error with using v0.18.9 of DataStructures and some projects depend on it already like the newest version of JuMP.

In general it would probably be helpful to use the Compat GitHub Action for this kind of PRs but it's a start.

Let me know if there are any problems with v0.18 that I'm not aware of.
