### PR TITLE
Add partial duplication + expanded findnz 

### DIFF
--- a/src/MatrixNetworks.jl
+++ b/src/MatrixNetworks.jl
@@ -92,7 +92,7 @@ export erdos_renyi_undirected, erdos_renyi_directed,
     pa_edges!, preferential_attachment_edges!,
     gpa_graph, generalized_preferential_attachment_graph,
     gpa_edges!, generalized_preferential_attachment_edges!, 
-    roach_graph, lollipop_graph
+    roach_graph, lollipop_graph, partial_duplication
 
 include("biconnected.jl")
 export biconnected_components, biconnected_components!

--- a/src/MatrixNetworks.jl
+++ b/src/MatrixNetworks.jl
@@ -52,6 +52,7 @@ export MatrixNetwork, sparse_transpose,
 include("scomponents.jl")
 include("csr_to_sparse.jl")
 include("sparse_to_csr.jl")
+export findnz 
 include("bipartite_matching.jl")
 include("bfs.jl")
 include("dfs.jl")

--- a/src/MatrixNetworks.jl
+++ b/src/MatrixNetworks.jl
@@ -36,7 +36,7 @@ Some available functions: (use ?function_name to get more documentation)
 - sparse_to_csr
 - pagerank
 - erdos_renyi_undirected
-- biconnected_components
+- partial_duplication
 - triangles
 
 You can check the readme file here: \n

--- a/src/MatrixNetworks.jl
+++ b/src/MatrixNetworks.jl
@@ -52,7 +52,6 @@ export MatrixNetwork, sparse_transpose,
 include("scomponents.jl")
 include("csr_to_sparse.jl")
 include("sparse_to_csr.jl")
-export findnz 
 include("bipartite_matching.jl")
 include("bfs.jl")
 include("dfs.jl")

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -827,7 +827,7 @@ edges between its neighbor with a given probability. In the original work
 the authors prove that new vertices will tend to become isolated for 
 p <= 0.567143. 
 
-paper src: 
+src: 
     Large-scale behavior of the partial duplication random graph
     Felix Hermann & Peter Pfaffelhuber
     https://arxiv.org/pdf/1408.0904.pdf
@@ -844,9 +844,9 @@ Output
 """ 
 function partial_duplication(A::MatrixNetwork{T},steps::Integer, new_edge_p::Float64) where T
  
-    is_undirected(A)                      || throw(ArgumentError("A must be undirected."))
-    (new_edge_p >= 0 && new_edge_p <= 1)  || throw(ArgumentError("new_edge_p must be a probability."))
-    steps >= 0                            || throw(ArgumentError("Must take a non-negative number of steps."))
+    is_undirected(A) || throw(ArgumentError("A must be undirected."))
+    (new_edge_p >= 0 && new_edge_p <= 1) || throw(ArgumentError("new_edge_p must be a probability."))
+    steps >= 0 || throw(ArgumentError("Must take a non-negative number of steps."))
     # let it steps equal 0 for testing purposes
 
     n,_ = size(A) # n will be updated

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -840,6 +840,7 @@ Output
 ------
 - A new undirected matrix network generated through the partial duplication 
   procedure. 
+- 'duplicated_vertices::Array{Int,1}': The list of vertices duplicated. 
 """ 
 function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) where T
  
@@ -849,7 +850,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
     # let it steps equal 0 for testing purposes
 
     n,_ = size(A) # n will be updated
-
+    duplicated_vertices = Array{Integer,1}(undef,steps)
 
     #store A as an edge list so it's fast to sample
     A_edge_list = Array{Array{Tuple{Int,T},1},1}(undef,n+steps)
@@ -863,6 +864,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
     for step in 1:steps
 
         dup_vertex = rand(1:n)
+        duplicated_vertices[step] = dup_vertex
         for (neighbor,weight) in A_edge_list[dup_vertex]
             if rand() < p
                 push!(A_edge_list[n+1],(neighbor,weight))
@@ -895,7 +897,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
 
     #compress to csr 
     At = sparse(Js,Is,Vs,n,n)
-    return MatrixNetwork(n,At.colptr,At.rowval,At.nzval)
+    return MatrixNetwork(n,At.colptr,At.rowval,At.nzval), duplicated_vertices
 
 end
 

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -851,13 +851,11 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
 
     n,_ = size(A) # n will be updated
 
-    get_row = (csr_A,i)->(csr_A.ci[csr_A.rp[i]:csr_A.rp[i+1]-1],
-                          csr_A.vals[csr_A.rp[i]:csr_A.rp[i+1]-1])
 
     #store A as an edge list so it's fast to sample
     A_edge_list = Array{Array{Tuple{Int,T},1},1}(undef,n+steps)
     for i = 1:n
-        A_edge_list[i] = collect(zip(get_row(A,i)...))
+        A_edge_list[i] = collect(zip(_get_row(A,i)...))
     end
     for i = n+1:n+steps
         A_edge_list[i] = Array{Tuple{Int,T},1}(undef,0)
@@ -902,3 +900,20 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
 
 end
 
+"""
+'_get_row'
+==========
+Helper function to extract out a row of a MatrixNetwork.
+
+Output
+------
+- 'nz_indices'::Array{Int,1}: non-zero column indices.
+- 'nz_weights'::Array{T,1}: non-zero weights.
+
+"""
+function _get_row(A::MatrixNetwork{T},i::Int) where T
+
+   (i >= 1 && i <= size(A,1)) || throw(ArgumentError("i must be in {1,...,size(A,1)}"))
+   return A.ci[A.rp[i]:A.rp[i+1]-1],A.vals[A.rp[i]:A.rp[i+1]-1]
+
+end

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -823,24 +823,23 @@ Usage
 A random graph model based off of the evolution of protein-protein interaction
 networks. The method takes an undirected graph and runs a number of steps 
 which randomly selects an existing vertex, duplicates the node, and keeps the
-edges between its neighbor with a given probability. In the original work 
-the authors prove that new vertices will tend to become isolated for 
-p <= 0.567143. 
-
-src: 
-    Large-scale behavior of the partial duplication random graph
-    Felix Hermann & Peter Pfaffelhuber
-    https://arxiv.org/pdf/1408.0904.pdf
+edges between its neighbor with a given probability.
 
 Input
 -----
-- 'A::MatrixNetwork{T}': seed matrix network 
-- `steps::Int': The number of steps to run the procedure
-- `p::Float64': the probability 
+- 'A::MatrixNetwork{T}': an undirected seed MatrixNetwork. 
+- `steps::Int': The number of steps to run the procedure.
+- `p::Float64': the probability to included each edge after duplication.
+
+Reference: 
+    A duplication growth model of gene expression networks 
+    Ashish Bhan, David J Galas, T. Gregory Dewey
+    https://doi.org/10.1093/bioinformatics/18.11.1486
 
 Output
 ------
-- a new matrix network generated through the partial duplication procedure. 
+- A new undirected matrix network generated through the partial duplication 
+  procedure. 
 """ 
 function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) where T
  

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -827,7 +827,10 @@ edges between its neighbor with a given probability. In the original work
 the authors prove that new vertices will tend to become isolated for 
 p <= 0.567143. 
 
- src: https://arxiv.org/pdf/1408.0904.pdf
+paper src: 
+    Large-scale behavior of the partial duplication random graph
+    Felix Hermann & Peter Pfaffelhuber
+    https://arxiv.org/pdf/1408.0904.pdf
 
 Input
 -----

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -874,7 +874,6 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
         n += 1
     end
 
-
     #convert edge list back into a MatrixNetwork
     total_edges = 0
     for i=1:n

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -855,7 +855,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
     #store A as an edge list so it's fast to sample
     A_edge_list = Array{Array{Tuple{Int,T},1},1}(undef,n+steps)
     for i = 1:n
-        A_edge_list[i] = collect(zip(_get_row(A,i)...))
+        A_edge_list[i] = collect(zip(_get_outedges(A,i)...))
     end
     for i = n+1:n+steps
         A_edge_list[i] = Array{Tuple{Int,T},1}(undef,0)
@@ -902,7 +902,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) whe
 end
 
 """
-'_get_row'
+'_get_outedges'
 ==========
 Helper function to extract out a row of a MatrixNetwork.
 
@@ -912,7 +912,7 @@ Output
 - 'nz_weights'::Array{T,1}: non-zero weights.
 
 """
-function _get_row(A::MatrixNetwork{T},i::Int) where T
+function _get_outedges(A::MatrixNetwork{T},i::Int) where T
 
    (i >= 1 && i <= size(A,1)) || throw(ArgumentError("i must be in {1,...,size(A,1)}"))
    return A.ci[A.rp[i]:A.rp[i+1]-1],A.vals[A.rp[i]:A.rp[i+1]-1]

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -836,16 +836,16 @@ Input
 -----
 - 'A::MatrixNetwork{T}': seed matrix network 
 - `steps::Int': The number of steps to run the procedure
-- `new_edge_p::Float64': the probability 
+- `p::Float64': the probability 
 
 Output
 ------
 - a new matrix network generated through the partial duplication procedure. 
 """ 
-function partial_duplication(A::MatrixNetwork{T},steps::Integer, new_edge_p::Float64) where T
+function partial_duplication(A::MatrixNetwork{T},steps::Integer, p::Float64) where T
  
     is_undirected(A) || throw(ArgumentError("A must be undirected."))
-    (new_edge_p >= 0 && new_edge_p <= 1) || throw(ArgumentError("new_edge_p must be a probability."))
+    (p >= 0 && p <= 1) || throw(ArgumentError("new_edge_p must be a probability."))
     steps >= 0 || throw(ArgumentError("Must take a non-negative number of steps."))
     # let it steps equal 0 for testing purposes
 
@@ -867,7 +867,7 @@ function partial_duplication(A::MatrixNetwork{T},steps::Integer, new_edge_p::Flo
 
         dup_vertex = rand(1:n)
         for (neighbor,weight) in A_edge_list[dup_vertex]
-            if rand() < new_edge_p
+            if rand() < p
                 push!(A_edge_list[n+1],(neighbor,weight))
                 push!(A_edge_list[neighbor],(n+1,weight))
             end

--- a/src/sparse_to_csr.jl
+++ b/src/sparse_to_csr.jl
@@ -29,39 +29,3 @@ function sparse_to_csr(nzi::Array{Int64,1},nzj::Array{Int64,1},
     At = sparse(nzj,nzi,nzv)
     return (At.colptr,At.rowval,At.nzval,At.m)
 end
-
-
-import SparseArrays: findnz   #import function to extend to MatrixNetwork type
-"""
-findnz
-======
-Returns the uncompressed non-zeros of the CSR representation of a MatrixNetwork.
-Js and Vs are copied from the CSR format, and Is is computed. 
-
-Output
-------
-- Is::Array{Integer,1}: the row indices.
-- Js::Array{Integer,1}: the columb indices.
-- Vs::Array{Integer,1}: the non-zero values.
-
-Example
--------
-Is, Js, Vs = findnz(A)
-"""
-function findnz(A::MatrixNetwork{T}) where T
-
-    Is = zeros(Int64,length(A.vals))
-    Js = copy(A.ci)
-    Vs = copy(A.vals)
-
-    idx = 1
-    for i in 1:(length(A.rp)-1)
-        row_nz = A.rp[i+1] - A.rp[i]
-        for _ in 1:row_nz
-            Is[idx] = i
-            idx += 1 
-        end
-    end
-
-    return Is,Js,Vs
-end

--- a/src/sparse_to_csr.jl
+++ b/src/sparse_to_csr.jl
@@ -29,3 +29,39 @@ function sparse_to_csr(nzi::Array{Int64,1},nzj::Array{Int64,1},
     At = sparse(nzj,nzi,nzv)
     return (At.colptr,At.rowval,At.nzval,At.m)
 end
+
+
+import SparseArrays: findnz   #import function to extend to MatrixNetwork type
+"""
+findnz
+======
+Returns the uncompressed non-zeros of the CSR representation of a MatrixNetwork.
+Js and Vs are copied from the CSR format, and Is is computed. 
+
+Output
+------
+- Is::Array{Integer,1}: the row indices.
+- Js::Array{Integer,1}: the columb indices.
+- Vs::Array{Integer,1}: the non-zero values.
+
+Example
+-------
+Is, Js, Vs = findnz(A)
+"""
+function findnz(A::MatrixNetwork{T}) where T
+
+    Is = zeros(Int64,length(A.vals))
+    Js = copy(A.ci)
+    Vs = copy(A.vals)
+
+    idx = 1
+    for i in 1:(length(A.rp)-1)
+        row_nz = A.rp[i+1] - A.rp[i]
+        for _ in 1:row_nz
+            Is[idx] = i
+            idx += 1 
+        end
+    end
+
+    return Is,Js,Vs
+end

--- a/test/generators_test.jl
+++ b/test/generators_test.jl
@@ -134,8 +134,6 @@ using LinearAlgebra
         A = sprand(100,100,.2)
         A = max.(A,A')
         B = MatrixNetwork(A)
-
-
         @test_throws ArgumentError partial_duplication(B,-1,.1)
         @test_throws ArgumentError partial_duplication(B,1,-.1)
         @test_throws ArgumentError partial_duplication(B,1,1.1)
@@ -175,15 +173,10 @@ using LinearAlgebra
 
         row_idx = rand(1:100)
         SA_Is, SA_Vs = findnz(A[row_idx,:])
-
-
         MN_Is, MN_Vs = MatrixNetworks._get_outedges(B,row_idx)
 
         @test MN_Is == SA_Is
         @test MN_Vs == SA_Vs
 
     end
-
-
-
 end

--- a/test/generators_test.jl
+++ b/test/generators_test.jl
@@ -163,21 +163,21 @@ using LinearAlgebra
 
     end
 
-    @testset "_get_row" begin
+    @testset "_get_outedges" begin
 
         A = sprand(100,100,.2)
         A = max.(A,A')
         B = MatrixNetwork(A)
 
-        @test_throws ArgumentError MatrixNetworks._get_row(B,-1)
-        @test_throws ArgumentError MatrixNetworks._get_row(B,101)
-        @inferred MatrixNetworks._get_row(B,50)
+        @test_throws ArgumentError MatrixNetworks._get_outedges(B,-1)
+        @test_throws ArgumentError MatrixNetworks._get_outedges(B,101)
+        @inferred MatrixNetworks._get_outedges(B,50)
 
         row_idx = rand(1:100)
         SA_Is, SA_Vs = findnz(A[row_idx,:])
 
 
-        MN_Is, MN_Vs = MatrixNetworks._get_row(B,row_idx)
+        MN_Is, MN_Vs = MatrixNetworks._get_outedges(B,row_idx)
 
         @test MN_Is == SA_Is
         @test MN_Vs == SA_Vs

--- a/test/generators_test.jl
+++ b/test/generators_test.jl
@@ -142,19 +142,23 @@ using LinearAlgebra
         @test_throws ArgumentError partial_duplication(MatrixNetwork(sprand(20,10,.1)),1,.1)
 
         #check edge list creation and conversion
-        C = partial_duplication(B,0,1.0)
+        C,dup_vertices = partial_duplication(B,0,1.0)
+        @test length(dup_vertices) == 0
         @test is_undirected(C)
         @test sparse(C) == A
 
         @inferred partial_duplication(B,100,.5)
+
         #check symmetry is preserved
-        C = partial_duplication(B,100,.5)
+        C,dup_vertices = partial_duplication(B,100,.5)
         @test is_undirected(C)
-        C = partial_duplication(B,100,.1)
+        @test length(dup_vertices) == 100
+        
+        C,_ = partial_duplication(B,100,.1)
         @test is_undirected(C)
 
         #check extremal proability case 
-        C = partial_duplication(B,100,0.0)
+        C,_ = partial_duplication(B,100,0.0)
         @test norm(sparse(C),2) == norm(A,2) # no new entries added
 
     end

--- a/test/generators_test.jl
+++ b/test/generators_test.jl
@@ -129,49 +129,57 @@ using LinearAlgebra
 
     end
 
-    @testset "partial duplication" begin 
+    @testset "partial_duplication" begin 
         
         A = sprand(100,100,.2)
         A = max.(A,A')
         B = MatrixNetwork(A)
 
-        @testset "get row" begin 
-            
-            row_idx = rand(1:100)
-            SA_Is, SA_Vs = findnz(A[row_idx,:])
 
-            get_row = (C,i)->(C.ci[C.rp[i]:C.rp[i+1]-1],C.vals[C.rp[i]:C.rp[i+1]-1])
-            MN_Is, MN_Vs = get_row(B,row_idx)
+        @test_throws ArgumentError partial_duplication(B,-1,.1)
+        @test_throws ArgumentError partial_duplication(B,1,-.1)
+        @test_throws ArgumentError partial_duplication(B,1,1.1)
+        @test_throws ArgumentError partial_duplication(MatrixNetwork(sprand(20,10,.1)),1,.1)
 
-            @test MN_Is == SA_Is 
-            @test MN_Vs == SA_Vs 
-            
-        end 
+        #check edge list creation and conversion
+        C = partial_duplication(B,0,1.0)
+        @test is_undirected(C)
+        @test sparse(C) == A
 
-        @testset "partial duplication" begin 
+        @inferred partial_duplication(B,100,.5)
+        #check symmetry is preserved
+        C = partial_duplication(B,100,.5)
+        @test is_undirected(C)
+        C = partial_duplication(B,100,.1)
+        @test is_undirected(C)
 
-            @test_throws ArgumentError partial_duplication(B,-1,.1)
-            @test_throws ArgumentError partial_duplication(B,1,-.1)
-            @test_throws ArgumentError partial_duplication(B,1,1.1)
-            @test_throws ArgumentError partial_duplication(MatrixNetwork(sprand(20,10,.1)),1,.1)
-
-            #check edge list creation and conversion
-            C = partial_duplication(B,0,1.0)
-            @test is_undirected(C)
-            @test sparse(C) == A
-
-            @inferred partial_duplication(B,100,.5)
-            #check symmetry is preserved
-            C = partial_duplication(B,100,.5)
-            @test is_undirected(C)
-            C = partial_duplication(B,100,.1)
-            @test is_undirected(C)
-
-            #check extremal proability case 
-            C = partial_duplication(B,100,0.0)
-            @test norm(sparse(C),2) == norm(A,2) # no new entries added
-
-        end
+        #check extremal proability case 
+        C = partial_duplication(B,100,0.0)
+        @test norm(sparse(C),2) == norm(A,2) # no new entries added
 
     end
+
+    @testset "_get_row" begin
+
+        A = sprand(100,100,.2)
+        A = max.(A,A')
+        B = MatrixNetwork(A)
+
+        @test_throws ArgumentError MatrixNetworks._get_row(B,-1)
+        @test_throws ArgumentError MatrixNetworks._get_row(B,101)
+        @inferred MatrixNetworks._get_row(B,50)
+
+        row_idx = rand(1:100)
+        SA_Is, SA_Vs = findnz(A[row_idx,:])
+
+
+        MN_Is, MN_Vs = MatrixNetworks._get_row(B,row_idx)
+
+        @test MN_Is == SA_Is
+        @test MN_Vs == SA_Vs
+
+    end
+
+
+
 end

--- a/test/sparse_to_csr_test.jl
+++ b/test/sparse_to_csr_test.jl
@@ -25,3 +25,20 @@
         @test A == A2
     end
 end
+
+
+
+@testset "findnz" begin 
+    #compare against findnz from SparseArrays
+
+    SA_A = sprand(100,80,0.01)
+    SA_nzs = Set(zip(findnz(SA_A)...))
+    # SparseArrays uses CSC, use set to ensure output is the same.
+
+    MN_A = MatrixNetwork(SA_A)
+    @inferred findnz(MN_A)
+    MN_nzs = Set(zip(findnz(MN_A)...))
+
+    @test SA_nzs == MN_nzs
+
+end

--- a/test/sparse_to_csr_test.jl
+++ b/test/sparse_to_csr_test.jl
@@ -25,5 +25,3 @@
         @test A == A2
     end
 end
-
-

--- a/test/sparse_to_csr_test.jl
+++ b/test/sparse_to_csr_test.jl
@@ -27,18 +27,3 @@
 end
 
 
-
-@testset "findnz" begin 
-    #compare against findnz from SparseArrays
-
-    SA_A = sprand(100,80,0.01)
-    SA_nzs = Set(zip(findnz(SA_A)...))
-    # SparseArrays uses CSC, use set to ensure output is the same.
-
-    MN_A = MatrixNetwork(SA_A)
-    @inferred findnz(MN_A)
-    MN_nzs = Set(zip(findnz(MN_A)...))
-
-    @test SA_nzs == MN_nzs
-
-end


### PR DESCRIPTION
Added in the [partial duplication noise model ](https://arxiv.org/pdf/1408.0904.pdf) to the generators.jl file with some simple tests. Happy to expand upon any of the tests. 

Additionally expanded the findnz function to the MatrixNetwork type as it was originally used as a helper function in the original routine. That function and tests were added in to the sparse_to_csr file as I wasn't sure where the best place for it to go would be. Given that I'm not using it after rewriting the function I can remove it from this pull request and submit another one if that functionality would be useful. 