### PR TITLE
Update Arpack compat to Arpack = "0.4, 0.5"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Arpack = "0.4.0"
+Arpack = "0.4, 0.5"
 DataStructures = "0.17.17, 0.18"
 IterTools = "1.3.0"
 KahanSummation = "0.1.0"


### PR DESCRIPTION
Increase range of compatibility constraint for Arpack to ensure compatibility with other packages (e.g. QuantumOptics.jl). Fixes #66.